### PR TITLE
use node resolved path to import `socketcluster-client` this allows p…

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict';
+const path = require('path');
 
 module.exports = {
     name: require('./package').name,
@@ -19,8 +20,14 @@ module.exports = {
             };
         }
 
+        const importJs = (module, file, options) => {
+            const modulePath = path.dirname(require.resolve(module));
+            this.import(`${modulePath}/${file}`, options);
+        };
+
         // import socketcluster for use in all fleetbase engines
         // this will become globally available as socketClusterClient
-        app.import('node_modules/socketcluster-client/socketcluster-client.min.js');
+        importJs('socketcluster-client', 'socketcluster-client.min.js');
+        // app.import('node_modules/socketcluster-client/socketcluster-client.min.js');
     },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fleetbase/ember-core",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "description": "Provides all the core services, decorators and utilities for building a Fleetbase extension for the Console.",
     "keywords": [
         "fleetbase-extension",


### PR DESCRIPTION
…ackages which depend on ember-core without install socketcluster-client for build