### PR TITLE
critical patch: register of widgets with `widgetId` not name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fleetbase/ember-core",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Provides all the core services, decorators and utilities for building a Fleetbase extension for the Console.",
   "keywords": [
     "fleetbase-core",


### PR DESCRIPTION
- critical patch for registering widget using identifier which cannot be obstructed by minified code