### PR TITLE
Add component context utility functions

### DIFF
--- a/addon/utils/apply-context-component-arguments.js
+++ b/addon/utils/apply-context-component-arguments.js
@@ -1,0 +1,33 @@
+import getModelName from '@fleetbase/ember-core/utils/get-model-name';
+import isModel from '@fleetbase/ember-core/utils/is-model';
+import { camelize } from '@ember/string';
+
+/**
+ * Applies context and dynamic arguments to a given component.
+ *
+ * @param {Component} component - The component to which context and arguments will be applied.
+ */
+export default function applyContextComponentArguments(component) {
+    const { context, dynamicArgs = {} } = component.args;
+
+    // Apply context model if available
+    if (context && isModel(context)) {
+        const contextModelName = camelize(getModelName(context));
+        if (contextModelName) {
+            component[contextModelName] = context;
+        }
+    }
+
+    // Execute any apply callback present in dynamic arguments
+    const { applyCallback } = dynamicArgs;
+    if (typeof applyCallback === 'function') {
+        applyCallback(component);
+    }
+
+    // Apply other dynamic arguments to the component
+    for (const [key, value] of Object.entries(dynamicArgs)) {
+        if (key !== 'applyCallback') {
+            component[key] = value;
+        }
+    }
+}

--- a/addon/utils/context-component-callback.js
+++ b/addon/utils/context-component-callback.js
@@ -1,0 +1,16 @@
+export default function contextComponentCallback(component, name, ...params) {
+    let callbackInvoked = false;
+
+    if (typeof component.args[name] === 'function') {
+        component.args[name](...params);
+        callbackInvoked = true;
+    }
+
+    // now do for context options
+    if (typeof component.args.options === 'object' && typeof component.args.options[name] === 'function') {
+        component.args.options[name](...params);
+        callbackInvoked = true;
+    }
+
+    return callbackInvoked;
+}

--- a/app/utils/apply-context-component-arguments.js
+++ b/app/utils/apply-context-component-arguments.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/ember-core/utils/apply-context-component-arguments';

--- a/app/utils/context-component-callback.js
+++ b/app/utils/context-component-callback.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/ember-core/utils/context-component-callback';

--- a/tests/unit/utils/apply-context-component-arguments-test.js
+++ b/tests/unit/utils/apply-context-component-arguments-test.js
@@ -1,0 +1,10 @@
+import applyContextComponentArguments from 'dummy/utils/apply-context-component-arguments';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | apply-context-component-arguments', function () {
+    // TODO: Replace this with your real tests.
+    test('it works', function (assert) {
+        let result = applyContextComponentArguments();
+        assert.ok(result);
+    });
+});

--- a/tests/unit/utils/context-component-callback-test.js
+++ b/tests/unit/utils/context-component-callback-test.js
@@ -1,0 +1,10 @@
+import contextComponentCallback from 'dummy/utils/context-component-callback';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | context-component-callback', function () {
+    // TODO: Replace this with your real tests.
+    test('it works', function (assert) {
+        let result = contextComponentCallback();
+        assert.ok(result);
+    });
+});


### PR DESCRIPTION
- `applyContextComponentArguments`: Applies context and dynamic arguments to components.
- `contextComponentCallback`: Invokes callback functions specified in component arguments.

These functions were moved from the fleetops repository to a shared location for wider usage.