### PR TITLE
v0.2.8

### DIFF
--- a/addon/services/universe.js
+++ b/addon/services/universe.js
@@ -592,10 +592,15 @@ export default class UniverseService extends Service.extend(Evented) {
 
         // register to registry
         const internalRegistryName = this.createInternalRegistryName(registryName);
-        if (isArray(this[internalRegistryName].renderableComponents)) {
-            this[internalRegistryName].renderableComponents.pushObject(component);
+        if (!isBlank(this[internalRegistryName])) {
+            if (isArray(this[internalRegistryName].renderableComponents)) {
+                this[internalRegistryName].renderableComponents.pushObject(component);
+            } else {
+                this[internalRegistryName].renderableComponents = [component];
+            }
         } else {
-            this[internalRegistryName].renderableComponents = [component];
+            this.createRegistry(registryName);
+            return this.registerRenderableComponent(...arguments);
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fleetbase/ember-core",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Provides all the core services, decorators and utilities for building a Fleetbase extension for the Console.",
   "keywords": [
     "fleetbase-core",


### PR DESCRIPTION
- Patched `UniverseService` `registerRenderableComponent()` method so that it initializez missing registry if component is being set to a registry that doesn't exist yet.