### PR TITLE
Phase 1: inject X-Company-Context header with localStorage persistence

### DIFF
--- a/addon/instance-initializers/validate-company-context.js
+++ b/addon/instance-initializers/validate-company-context.js
@@ -1,0 +1,76 @@
+import { debug } from '@ember/debug';
+import { ACTIVE_COMPANY_CONTEXT_STORAGE_KEY } from '../services/current-user';
+
+/**
+ * Validate-company-context instance initializer.
+ *
+ * On app boot, if a previously-selected company context UUID is persisted in
+ * localStorage, validate it with the backend before any business-logic
+ * requests go out. A UUID that the backend no longer accepts (401/403) —
+ * because the user's membership in that company was revoked, or the company
+ * was deleted — must be cleared so subsequent requests fall back to the
+ * user's default company via the backend's `Auth::getCompany()` chain.
+ *
+ * Behaviour:
+ *   - No stored UUID → no-op. Backend uses default company on first request.
+ *   - Stored UUID + session unauthenticated → no-op. The regular auth flow
+ *     will run first; header injection only happens when authenticated
+ *     anyway, and a user re-login will re-run initializers.
+ *   - Stored UUID + 200 from /v1/companies/current-context → keep.
+ *   - Stored UUID + 401/403 → clear localStorage + in-memory tracked state.
+ *   - Any other error (network, 5xx) → leave as-is. A real business-logic
+ *     request will surface the real error; we don't want transient failures
+ *     to silently destroy the user's context selection.
+ */
+function readStoredContext() {
+    try {
+        const value = window.localStorage.getItem(ACTIVE_COMPANY_CONTEXT_STORAGE_KEY);
+        return typeof value === 'string' && value.length > 0 ? value : null;
+    } catch (_e) {
+        return null;
+    }
+}
+
+export async function initialize(appInstance) {
+    const stored = readStoredContext();
+    if (!stored) {
+        return;
+    }
+
+    const currentUser = appInstance.lookup('service:current-user');
+    const fetch = appInstance.lookup('service:fetch');
+    const session = appInstance.lookup('service:session');
+
+    if (!currentUser || !fetch) {
+        return;
+    }
+
+    // Mirror the stored UUID into the tracked service property so the
+    // validation request itself carries `X-Company-Context`.
+    currentUser.activeCompanyContext = stored;
+
+    // Only validate when authenticated — an anonymous visitor has no
+    // membership to check, and the backend endpoint requires auth.
+    if (!session?.isAuthenticated) {
+        return;
+    }
+
+    try {
+        await fetch.get('v1/companies/current-context');
+        // 200: keep.
+    } catch (err) {
+        const status = err?.response?.status ?? err?.status;
+        if (status === 401 || status === 403) {
+            debug(`[validate-company-context] Clearing revoked company context UUID (status ${status}).`);
+            currentUser.activeCompanyContext = null;
+        }
+        // Other errors: leave untouched. Business-logic requests will surface
+        // the real problem; we don't want to clobber a valid selection over a
+        // transient network blip.
+    }
+}
+
+export default {
+    name: 'validate-company-context',
+    initialize,
+};

--- a/addon/services/current-user.js
+++ b/addon/services/current-user.js
@@ -10,6 +10,21 @@ import { storageFor } from 'ember-local-storage';
 import { debug } from '@ember/debug';
 import lookupUserIp from '../utils/lookup-user-ip';
 
+// Single source of truth for the persisted active company context key.
+// Exported so tests and other services (e.g. the validate-company-context
+// instance initializer) can agree on the storage slot without duplication.
+export const ACTIVE_COMPANY_CONTEXT_STORAGE_KEY = 'fleetbase.activeCompanyContext';
+
+function readStoredActiveCompanyContext() {
+    try {
+        const value = window.localStorage.getItem(ACTIVE_COMPANY_CONTEXT_STORAGE_KEY);
+        return typeof value === 'string' && value.length > 0 ? value : null;
+    } catch (_e) {
+        // private browsing / storage disabled
+        return null;
+    }
+}
+
 /**
  * CurrentUserService
  *
@@ -46,6 +61,43 @@ export default class CurrentUserService extends Service.extend(Evented) {
     @tracked organizations = [];
     @tracked whoisData = {};
     @tracked locale = 'en-us';
+
+    /**
+     * Active company context UUID for multi-tenant hierarchy.
+     *
+     * Backed by localStorage; read-through on first access, write-through on
+     * set. A `null` value means "no header" — the backend falls back to the
+     * user's default company via `Auth::getCompany()`.
+     *
+     * This is the single source of truth the fetch service reads at request
+     * assembly time. Never cache the value off this getter — always re-read
+     * so reactivity works when a switcher updates it.
+     *
+     * @private
+     */
+    @tracked _activeCompanyContext = readStoredActiveCompanyContext();
+
+    get activeCompanyContext() {
+        return this._activeCompanyContext;
+    }
+
+    set activeCompanyContext(value) {
+        const normalized = typeof value === 'string' && value.length > 0 ? value : null;
+        this._activeCompanyContext = normalized;
+        try {
+            if (normalized) {
+                window.localStorage.setItem(ACTIVE_COMPANY_CONTEXT_STORAGE_KEY, normalized);
+            } else {
+                window.localStorage.removeItem(ACTIVE_COMPANY_CONTEXT_STORAGE_KEY);
+            }
+        } catch (_e) {
+            // private browsing / storage disabled — ignore, in-memory value still tracked
+        }
+    }
+
+    clearActiveCompanyContext() {
+        this.activeCompanyContext = null;
+    }
 
     @storageFor('user-options') options;
     @storageFor('local-cache') cache;

--- a/addon/services/fetch.js
+++ b/addon/services/fetch.js
@@ -84,6 +84,16 @@ export default class FetchService extends Service {
             headers['Access-Console-Sandbox-Key'] = testKey;
         }
 
+        // Multi-tenant hierarchy: inject active company context header when
+        // the user has selected a non-default company. Read from currentUser
+        // at request-assembly time (never cached) so reactivity works — a
+        // switcher updating `currentUser.activeCompanyContext` is reflected
+        // on the very next request.
+        const activeCompanyContext = this.currentUser?.activeCompanyContext;
+        if (activeCompanyContext) {
+            headers['X-Company-Context'] = activeCompanyContext;
+        }
+
         return headers;
     }
 

--- a/app/instance-initializers/validate-company-context.js
+++ b/app/instance-initializers/validate-company-context.js
@@ -1,0 +1,1 @@
+export { default, initialize } from '@fleetbase/ember-core/instance-initializers/validate-company-context';

--- a/tests/unit/services/fetch-company-context-test.js
+++ b/tests/unit/services/fetch-company-context-test.js
@@ -1,0 +1,91 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'dummy/tests/helpers';
+import Service from '@ember/service';
+import { ACTIVE_COMPANY_CONTEXT_STORAGE_KEY } from '@fleetbase/ember-core/services/current-user';
+
+// Minimal session stub — getHeaders() reads session.isAuthenticated and
+// session.data.authenticated.{user,token}. We leave the user unauthenticated
+// so the auth branches short-circuit and we're only exercising the company
+// context branch under test.
+class StubSessionService extends Service {
+    isAuthenticated = false;
+    data = { authenticated: { user: null, token: null } };
+}
+
+module('Unit | Service | fetch | X-Company-Context header injection', function (hooks) {
+    setupTest(hooks);
+
+    hooks.beforeEach(function () {
+        this.owner.register('service:session', StubSessionService);
+        // Ensure no stale localStorage bleeds between tests.
+        try {
+            window.localStorage.removeItem(ACTIVE_COMPANY_CONTEXT_STORAGE_KEY);
+        } catch (_e) {
+            /* ignore */
+        }
+    });
+
+    hooks.afterEach(function () {
+        try {
+            window.localStorage.removeItem(ACTIVE_COMPANY_CONTEXT_STORAGE_KEY);
+        } catch (_e) {
+            /* ignore */
+        }
+    });
+
+    test('getHeaders includes X-Company-Context when currentUser.activeCompanyContext is set', function (assert) {
+        const currentUser = this.owner.lookup('service:current-user');
+        currentUser.activeCompanyContext = 'test-uuid-123';
+
+        const fetchService = this.owner.lookup('service:fetch');
+        const headers = fetchService.getHeaders();
+
+        assert.strictEqual(headers['X-Company-Context'], 'test-uuid-123', 'header carries the active context UUID');
+    });
+
+    test('getHeaders omits X-Company-Context when no context is set', function (assert) {
+        const currentUser = this.owner.lookup('service:current-user');
+        currentUser.activeCompanyContext = null;
+
+        const fetchService = this.owner.lookup('service:fetch');
+        const headers = fetchService.getHeaders();
+
+        assert.notOk('X-Company-Context' in headers, 'no header when context is null');
+    });
+
+    test('header read is reactive — updates when currentUser.activeCompanyContext changes', function (assert) {
+        const currentUser = this.owner.lookup('service:current-user');
+        const fetchService = this.owner.lookup('service:fetch');
+
+        currentUser.activeCompanyContext = 'uuid-a';
+        assert.strictEqual(fetchService.getHeaders()['X-Company-Context'], 'uuid-a', 'first value picked up');
+
+        currentUser.activeCompanyContext = 'uuid-b';
+        assert.strictEqual(fetchService.getHeaders()['X-Company-Context'], 'uuid-b', 'subsequent change picked up (no stale caching)');
+
+        currentUser.activeCompanyContext = null;
+        assert.notOk('X-Company-Context' in fetchService.getHeaders(), 'clearing removes the header');
+    });
+
+    test('activeCompanyContext setter persists to localStorage; clearing removes the key', function (assert) {
+        const currentUser = this.owner.lookup('service:current-user');
+
+        currentUser.activeCompanyContext = 'persist-me-uuid';
+        assert.strictEqual(
+            window.localStorage.getItem(ACTIVE_COMPANY_CONTEXT_STORAGE_KEY),
+            'persist-me-uuid',
+            'UUID persisted to localStorage on set'
+        );
+
+        currentUser.activeCompanyContext = null;
+        assert.strictEqual(
+            window.localStorage.getItem(ACTIVE_COMPANY_CONTEXT_STORAGE_KEY),
+            null,
+            'localStorage key removed on clear'
+        );
+
+        // Empty/invalid values normalize to null.
+        currentUser.activeCompanyContext = '';
+        assert.strictEqual(currentUser.activeCompanyContext, null, 'empty string normalizes to null');
+    });
+});


### PR DESCRIPTION
## Summary

Part of Phase 1 multi-tenant hierarchy work for the fleetbase TMS.

Adds client-side active-company-context state and wires it into the shared `fetch` service so every API request carries `X-Company-Context: <uuid>` when a context is set. Includes boot-time validation that clears the stored UUID if the backend rejects it (401/403).

## What changes

- `addon/services/current-user.js` — new `activeCompanyContext` getter/setter backed by `window.localStorage` under key `fleetbase.activeCompanyContext`. Also exports `ACTIVE_COMPANY_CONTEXT_STORAGE_KEY` constant + `clearActiveCompanyContext()` helper.
- `addon/services/fetch.js` — `getHeaders()` now injects `X-Company-Context` from `currentUser.activeCompanyContext` at request-assembly time (read fresh each call; reactive).
- `addon/instance-initializers/validate-company-context.js` — boot-time: reads stored UUID, calls `GET /v1/companies/current-context` to validate; clears localStorage on 401/403.
- `app/instance-initializers/validate-company-context.js` — re-export shim.
- `tests/unit/services/fetch-company-context-test.js` — unit coverage for header presence / absence / reactivity / localStorage persistence.

## Dependencies

- Requires core-api PR (`GET /v1/companies/current-context` endpoint + `CompanyContextResolver` middleware) to land first.

## Test plan

- [ ] QUnit: `pnpm test --filter "X-Company-Context"` → 3 unit tests pass
- [ ] Manual: in console dev-build, `localStorage.setItem('fleetbase.activeCompanyContext', '<valid uuid>')` then reload → Network panel shows header; set invalid UUID → `/v1/companies/current-context` returns 403 and localStorage is cleared on next boot.